### PR TITLE
Add fix for Android 10+

### DIFF
--- a/app/src/main/jni/And64InlineHook/And64InlineHook.cpp
+++ b/app/src/main/jni/And64InlineHook/And64InlineHook.cpp
@@ -601,6 +601,9 @@ A64_JNIEXPORT void A64HookFunction(void *const symbol, void *const replace, void
         if (trampoline == NULL) return;
     } //if
 
+    //fix Android 10 .text segment is read-only by default
+    __make_rwx(symbol, 5 * sizeof(size_t));
+ 
     trampoline = A64HookFunctionV(symbol, replace, trampoline, A64_MAX_INSTRUCTIONS * 10u);
     if (trampoline == NULL && result != NULL) {
         *result = NULL;


### PR DESCRIPTION
https://github.com/Rprop/And64InlineHook/pull/6

Works fine on my Android 11 phone on an il2cpp game, but still doesn't work with dlsym hook on Sky children of the light. I'm not sure why, it worked fine with DobbyHook